### PR TITLE
Bump node.js to v6.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y install wget python build-essential && \
     cd /tmp && \
     wget --progress=dot:mega \
-      https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.xz && \
+      https://nodejs.org/dist/latest-v6.x/node-v6.17.1-linux-x64.tar.xz && \
     tar -xJf node-v*.tar.xz --strip-components 1 -C /usr/local && \
     rm node-v*.tar.xz && \
     su stf-build -s /bin/bash -c '/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js install' && \

--- a/docker/armv7l/Dockerfile
+++ b/docker/armv7l/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xo pipefail && \
     apk update && \
     echo '--- Building node' && \
     apk add curl make gcc g++ binutils-gold python linux-headers paxctl libgcc libstdc++ && \
-    curl -sSL https://nodejs.org/dist/v6.11.2/node-v6.11.2.tar.gz | tar -xz && \
+    curl -sSL https://nodejs.org/dist/latest-v6.x/node-v6.17.1.tar.gz | tar -xz && \
     cd /node-v* && \
     ./configure --prefix=/usr && \
     make -j$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \


### PR DESCRIPTION
## Why?

`6.11.2` version doesn't available right now. Need to use latest version from v.6.x.