### PR TITLE
Has been updated wdaClient logs output.

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -133,7 +133,8 @@ module.exports = syrup.serial()
         })
       },
       size: function() {
-	log.info(" window size: ${this.baseUrl}/session/${this.sessionId}/window/size")
+        log.info(`window size: ${this.baseUrl}/session/${this.sessionId}/window/size`)
+
         return new Promise((resolve, reject) => {
           this.handleRequest({
             method: 'GET',
@@ -301,6 +302,7 @@ module.exports = syrup.serial()
       return new Promise((resolve, reject) => {
         request(requestOpt)
           .then(response => {
+            log.verbose('Has been sent api request to WDA with data :', JSON.stringify(requestOpt))
             return resolve(response)
           })
           .catch(err => {
@@ -308,6 +310,7 @@ module.exports = syrup.serial()
             this.connect()
               .then(() => {
                 const newUri = requestOpt.uri.replace(oldSessionId, this.sessionId)
+                log.verbose('Has been sent api request to WDA with data :', JSON.stringify(requestOpt))
                 return request(Object.assign({}, requestOpt, {
                   uri: newUri
                 }))


### PR DESCRIPTION
Update wdaClient output logs due to client wishes 
```
My wishes:
a) print to log info about get/post request
b) show actual values in log instead of "${this.sessionId}"
c) show in log each implemented wda command
```