### PR TITLE
Have been added error handler for WebSocker server connection

### DIFF
--- a/lib/units/device/plugins/screen/stream.js
+++ b/lib/units/device/plugins/screen/stream.js
@@ -580,6 +580,11 @@ module.exports = syrup.serial()
             clearInterval(pingTimer)
             broadcastSet.remove(id)
           })
+
+          ws.on('error', function(e) {
+            clearInterval(pingTimer)
+            broadcastSet.remove(id)
+          })
         })
 
         lifecycle.observe(function() {


### PR DESCRIPTION
**Steps to repro bug**

1. Open any android device.
2. reload the page by clicking cmd/cntrl + R.

**Actual result:**

 Error modal appears.

**Expected behavior:**

Page reloads without error message.

**The flow**

Websocket server doesn't have error handler.