### PR TITLE
#81: have been fixed issue with home btn

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -8,6 +8,8 @@ let iosutil = {
         return '\r'
       case 'del':
         return '\x08'
+      case 'home':
+        return null
       default:
         return key
     }
@@ -36,6 +38,8 @@ let iosutil = {
         return this.appActivate('com.apple.camera')
       case 'search':
         return this.appActivate('com.apple.mobilesafari')
+      case 'home':
+        return this.homeBtn()
       case 'mute': {
         let i
           for(i = 0; i < 25; i++) {

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -152,12 +152,16 @@ module.exports = syrup.serial()
         })
       },
       typeKey: function(params) {
-          return this.handleRequest({
-            method: 'POST',
-            uri: `${this.baseUrl}/session/${this.sessionId}/wda/keys`,
-            body: params,
-            json: true
-          })
+        if (!params.value || !params.value[0]) {
+          return
+        }
+
+        return this.handleRequest({
+          method: 'POST',
+          uri: `${this.baseUrl}/session/${this.sessionId}/wda/keys`,
+          body: params,
+          json: true
+        })
       },
       openUrl: function(message) {
         const params = {


### PR DESCRIPTION
**have been fixed issue with home btn**

WDA's endpoint `${ip}/session/${session_id}/wda/keys` - with body `{value: ['home']}` works super slow at ios 13.1, so this endpoint for home button has replaced in preference -  `${ip}/wda/homescreen`