### PR TITLE
istf-#104: have been removed vnc-port from list of obligatory params …

### DIFF
--- a/lib/cli/ios-device/index.js
+++ b/lib/cli/ios-device/index.js
@@ -138,11 +138,6 @@ module.exports.builder = function(yargs) {
         return val.split('x').map(Number)
       }
     })
-    .option('vnc-port', {
-      describe: 'Port allocated to VNC connections.'
-      , type: 'number'
-      , demand: true
-    })
     .option('connect-app-dealer', {
       describe: 'App-side ZeroMQ DEALER endpoint to connect to.'
       , array: true


### PR DESCRIPTION
…for ios-device service
The fix of - https://github.com/qaprosoft/stf/issues/104