### PR TITLE
Istf #108 make ios device completely independent of wda

### DIFF
--- a/lib/units/ios-device/plugins/devicenotifier.js
+++ b/lib/units/ios-device/plugins/devicenotifier.js
@@ -21,7 +21,7 @@ module.exports = syrup.serial()
             ))
           ])
 
-          this.setDeviceAbsent(err)
+          // this.setDeviceAbsent(err)
         })
         .catch(err => {
           log.error('Cannot set device temporary unavialable', err)
@@ -29,14 +29,14 @@ module.exports = syrup.serial()
     }
 
     notifier.setDeviceAbsent = function(err) {
-      push.send([
-        wireutil.global
-        , wireutil.envelope(new wire.DeviceAbsentMessage(
-          options.serial
-        ))
-      ])
+      // push.send([
+      //   wireutil.global
+      //   , wireutil.envelope(new wire.DeviceAbsentMessage(
+      //     options.serial
+      //   ))
+      // ])
 
-      lifecycle.graceful(err)
+      // lifecycle.graceful(err)
     }
 
     return notifier

--- a/lib/units/ios-device/plugins/devicenotifier.js
+++ b/lib/units/ios-device/plugins/devicenotifier.js
@@ -20,8 +20,6 @@ module.exports = syrup.serial()
               options.serial
             ))
           ])
-
-          // this.setDeviceAbsent(err)
         })
         .catch(err => {
           log.error('Cannot set device temporary unavialable', err)
@@ -29,14 +27,14 @@ module.exports = syrup.serial()
     }
 
     notifier.setDeviceAbsent = function(err) {
-      // push.send([
-      //   wireutil.global
-      //   , wireutil.envelope(new wire.DeviceAbsentMessage(
-      //     options.serial
-      //   ))
-      // ])
+      push.send([
+        wireutil.global
+        , wireutil.envelope(new wire.DeviceAbsentMessage(
+          options.serial
+        ))
+      ])
 
-      // lifecycle.graceful(err)
+      lifecycle.graceful(err)
     }
 
     return notifier

--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -1,11 +1,13 @@
 const syrup = require('stf-syrup')
+const events = require('events')
 const webSocketServer = require('ws')
 const websocketStream = require('websocket-stream')
 const MjpegConsumer = require('mjpeg-consumer')
+const Promise = require('bluebird')
 const request = require('request')
+
 const logger = require('../../../../util/logger')
 const iosutil = require('../util/iosutil')
-
 
 module.exports = syrup.serial()
   .dependency(require('../solo'))
@@ -13,13 +15,14 @@ module.exports = syrup.serial()
   .define(function(options, solo, notifier) {
       const log = logger.createLogger('device:plugins:screen:stream')
       const wss = new webSocketServer.Server({port: options.screenPort})
+      const waiter = new events.EventEmitter()
 
       let url = iosutil.getUri(options.wdaHost, options.mjpegPort || options.connectPort)
       wss.on('connection', (ws) => {
         ws.isAlive = true
 
         const consumer = new MjpegConsumer()
-        const frameStream = request.get(url)
+        let frameStream
         let stream = websocketStream(ws)
 
         function handleSocketError(err, message) {
@@ -28,12 +31,45 @@ module.exports = syrup.serial()
           ws.close()
         }
 
-        frameStream.on('error', function(err) {
-          handleSocketError(err, 'frameStrem error ')
-        })
+        const handleRequestStream = () => {
+          return new Promise((resolve, reject) => {
+            setTimeout(() => {
+              frameStream = request.get(url)
+              log.info('executed handleRequestStream')
+
+              frameStream.on('response', response => {
+                reject({response, frameStream})
+              })
+              frameStream.on('error', err => {
+                resolve()
+              })
+            }, 1000)
+          })
+        }
+
+        const getRequestStream = () => {
+          let chain = Promise.resolve()
+
+          for(let i = 0; i < 10; i++) {
+            chain = chain.then(() => handleRequestStream())
+          }
+
+          chain
+            .then(() => handleSocketError({message: 'Connection failed to WDA MJPEG port'}, 'Consumer error'))
+            .catch(result => {
+              result.response.pipe(consumer).pipe(stream)
+
+              // override already existing error handler
+              result.frameStream.on('error', function(err) {
+                //handleSocketError(err, 'frameStrem error ')
+                getRequestStream()
+              })
+            })
+        }
 
         consumer.on('error', err => {
           handleSocketError(err, 'Consumer error')
+          //doConnectionToMJPEGStream(fn)
         })
 
         stream.on('error', err => {
@@ -44,14 +80,7 @@ module.exports = syrup.serial()
           //handleSocketError(err, 'Websocket stream error ')
         })
 
-        try {
-          frameStream.pipe(consumer).pipe(stream)
-        }
-        catch(e) {
-          log.error('Catch stream exception ', e)
-          ws.close()
-          solo.poke()
-        }
+        getRequestStream()
 
         ws.on('close', function() {
           // @TODO handle close event

--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -1,5 +1,4 @@
 const syrup = require('stf-syrup')
-const events = require('events')
 const webSocketServer = require('ws')
 const websocketStream = require('websocket-stream')
 const MjpegConsumer = require('mjpeg-consumer')
@@ -15,14 +14,15 @@ module.exports = syrup.serial()
   .define(function(options, solo, notifier) {
       const log = logger.createLogger('device:plugins:screen:stream')
       const wss = new webSocketServer.Server({port: options.screenPort})
-      const waiter = new events.EventEmitter()
 
       let url = iosutil.getUri(options.wdaHost, options.mjpegPort || options.connectPort)
       wss.on('connection', (ws) => {
         ws.isAlive = true
+        let isConnectionAlive = true
 
         const consumer = new MjpegConsumer()
         let frameStream
+        let chain = Promise.resolve()
         let stream = websocketStream(ws)
 
         function handleSocketError(err, message) {
@@ -35,21 +35,23 @@ module.exports = syrup.serial()
           return new Promise((resolve, reject) => {
             setTimeout(() => {
               frameStream = request.get(url)
-              log.info('executed handleRequestStream')
 
               frameStream.on('response', response => {
                 reject({response, frameStream})
               })
               frameStream.on('error', err => {
-                resolve()
+                // checking for ws connection in order to stop chain promise if connection closed
+                if (isConnectionAlive) {
+                  resolve()
+                } else {
+                  reject()
+                }
               })
             }, 1000)
           })
         }
 
         const getRequestStream = () => {
-          let chain = Promise.resolve()
-
           for(let i = 0; i < 10; i++) {
             chain = chain.then(() => handleRequestStream())
           }
@@ -57,13 +59,14 @@ module.exports = syrup.serial()
           chain
             .then(() => handleSocketError({message: 'Connection failed to WDA MJPEG port'}, 'Consumer error'))
             .catch(result => {
-              result.response.pipe(consumer).pipe(stream)
+              if(result) {
+                result.response.pipe(consumer).pipe(stream)
 
               // override already existing error handler
               result.frameStream.on('error', function(err) {
-                //handleSocketError(err, 'frameStrem error ')
-                getRequestStream()
+                handleSocketError(err, 'frameStrem error ')
               })
+              }
             })
         }
 
@@ -80,15 +83,19 @@ module.exports = syrup.serial()
           //handleSocketError(err, 'Websocket stream error ')
         })
 
-        getRequestStream()
-
         ws.on('close', function() {
           // @TODO handle close event
           //stream.socket.onclose()
+          isConnectionAlive = false
+          log.important('ws on close event')
         })
         ws.on('error', function() {
           // @TODO handle error event
           //stream.socket.onclose()
+          isConnectionAlive = false
+          log.important('ws on error event')
         })
+
+        getRequestStream()
       })
   })

--- a/res/app/components/stf/common-ui/modals/temporarily-unavialable/temporarily-unavialable-service.js
+++ b/res/app/components/stf/common-ui/modals/temporarily-unavialable/temporarily-unavialable-service.js
@@ -12,13 +12,13 @@ module.exports =
 
       $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel')
-        document.getElementById('temporarily-unavialable').remove()
+        //document.getElementById('temporarily-unavialable').remove()
       }
 
       $scope.second = function() {
         $uibModalInstance.dismiss()
         $location.path('/devices/')
-        document.getElementById('temporarily-unavialable').remove()
+        //document.getElementById('temporarily-unavialable').remove()
       }
 
     }

--- a/res/app/components/stf/common-ui/modals/temporarily-unavialable/temporarily-unavialable-service.js
+++ b/res/app/components/stf/common-ui/modals/temporarily-unavialable/temporarily-unavialable-service.js
@@ -12,11 +12,13 @@ module.exports =
 
       $scope.cancel = function() {
         $uibModalInstance.dismiss('cancel')
+        document.getElementById('temporarily-unavialable').remove()
       }
 
       $scope.second = function() {
         $uibModalInstance.dismiss()
         $location.path('/devices/')
+        document.getElementById('temporarily-unavialable').remove()
       }
 
     }

--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -71,7 +71,7 @@ module.exports = function DeviceScreenDirective(
         ws.onclose = function closeListener(event) {
           // @todo Maybe handle
           console.log('closeListener', event)
-          TemporarilyUnavialableService.open('Device temporarily unavailable')
+          TemporarilyUnavialableService.open('WDA is currently unavailable try your attempt later')
         }
 
         ws.onopen = function openListener() {

--- a/res/app/components/stf/socket/socket-service.js
+++ b/res/app/components/stf/socket/socket-service.js
@@ -43,7 +43,7 @@ module.exports = function SocketFactory(
   })
 
   socket.once('temporarily-unavailable', function() {
-    TemporarilyUnavialableService.open('Device temporarily unavailable')
+    TemporarilyUnavialableService.open('WDA is currently unavailable try your attempt later')
   })
 
   return socket


### PR DESCRIPTION
Have been updated ios-device service, these changes make service more independent of WDA and in the case of WDA's disconnection, the process will not stop(kill) itself.