### PR TITLE
#177 Fixing Landscape Mode tapping/swipping in iOS

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -94,10 +94,10 @@ let iosutil = {
         }
       case 'LANDSCAPE':
         return {
-          toX: params.fromY * deviceSize.width,
-          toY: params.fromX * deviceSize.height,
-          fromX: params.toY * deviceSize.width,
-          fromY: params.toX * deviceSize.height,
+          fromX: params.fromX * deviceSize.width,
+          fromY: params.fromY * deviceSize.height,
+          toX: params.toX * deviceSize.width,
+          toY: params.toY * deviceSize.height,
           duration: params.duration
         }
       default:

--- a/res/app/components/stf/screen/scaling/scaling-service.js
+++ b/res/app/components/stf/screen/scaling/scaling-service.js
@@ -48,8 +48,10 @@ module.exports = function ScalingServiceFactory() {
      * |--------------|------|---------|---------|---------|
      */
     return {
-      coords: function(boundingW, boundingH, relX, relY, rotation) {
+      coords: function(boundingW, boundingH, relX, relY, rotation, ios) {
         var w, h, x, y, ratio, scaledValue
+
+        let isIosDevice = ios
 
         switch (rotation) {
         case 0:
@@ -63,21 +65,29 @@ module.exports = function ScalingServiceFactory() {
           h = boundingW
           x = boundingH - relY
           y = relX
-          break
-        case 180:
-          w = boundingW
-          h = boundingH
-          x = boundingW - relX
-          y = boundingH - relY
-          break
-        case 270:
-          w = boundingH
-          h = boundingW
-          x = relY
-          y = boundingW - relX
-          break
-        }
 
+          // X and Y are inverted on iOS
+          if (isIosDevice) {
+            w = boundingH
+            h = boundingW
+            x = relY
+            y = relX
+          }
+          break
+          case 180:
+            w = boundingW
+            h = boundingH
+            x = boundingW - relX
+            y = boundingH - relY
+            break
+          case 270:
+            w = boundingH
+            h = boundingW
+            x = relY
+            y = boundingW - relX
+            break
+          }
+ 
         ratio = w / h
 
         if (realRatio > ratio) {
@@ -130,6 +140,14 @@ module.exports = function ScalingServiceFactory() {
 
           w = scaledValue
         }
+
+        if (rotation === 90 && isIosDevice) {
+          return {
+            xP: y / h,
+            yP: x / w
+          }
+        }
+
         return {
           xP: x / w
         , yP: y / h

--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -607,6 +607,7 @@ module.exports = function DeviceScreenDirective(
               , x
               , y
               , screen.rotation
+              , device.ios
               )
           prevCoords = {
             x: scaled.xP,
@@ -680,6 +681,7 @@ module.exports = function DeviceScreenDirective(
               , x
               , y
               , screen.rotation
+              , device.ios
               )
 
           control.touchMove(nextSeq(), 0, scaled.xP, scaled.yP, pressure)
@@ -734,6 +736,7 @@ module.exports = function DeviceScreenDirective(
             , x
             , y
             , screen.rotation
+            , device.ios
           )
 
           if ((Math.abs(prevCoords.x - scaled.xP) >= 0.1 || Math.abs(prevCoords.y - scaled.yP) >= 0.1) && device.ios && device.ios === true) {
@@ -881,6 +884,7 @@ module.exports = function DeviceScreenDirective(
                 , x
                 , y
                 , screen.rotation
+                , device.ios
                 )
 
             slotted[touch.identifier] = slot
@@ -919,6 +923,7 @@ module.exports = function DeviceScreenDirective(
                 , x
                 , y
                 , screen.rotation
+                , device.ios
                 )
 
             control.touchMove(nextSeq(), slot, scaled.xP, scaled.yP, pressure)


### PR DESCRIPTION
The folllowing changes fix tapping and swiping in Landscape mode for iOS devices.

After trying and failing several times, I found a working configuration for the scaling service in iOS devices:

- The width/height boundaries need to remain as the same as before.

- Both `x` and `y` coordinates work differently in iOS. The `x` coordinate value needs to be set with `relY` value and the `y` coordinate with the `relX` value.

- The `xP` and `yP` need to switch their values for iOS.

- The coords function now receives `device.ios` as an argument, to check the device OS and use the correct configuration (in Android the Landscape mode works fine, so no need to change its logic)

- Finally both Landscape/Portrait mode swiping works the same way.