### PR TITLE
#847 Capture error, set Unhealthy and exit process

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -294,11 +294,21 @@ module.exports = function(options) {
                 , device.id
                 , err.code
               )
-              log.info('Restarting device worker "%s"', device.id)
-              return Promise.delay(500)
-                .then(function() {
-                  return work()
-                })
+              // #847 exit process and set Unhealthy status, 
+              // not restarting since it must be reviewed manually
+              push.send([
+                wireutil.global,
+                wireutil.envelope(new wire.DeviceStatusMessage(
+                  device.id,
+                  7
+                ))
+              ])
+              return lifecycle.fatal()
+              // log.info('Restarting device worker "%s"', device.id)
+              // return Promise.delay(500)
+              //   .then(function() {
+              //     return work()
+              //   })
             }
           })
       }


### PR DESCRIPTION
The following PR replaces automatic restarts: it sets Unhealthy status and then, exit the process