### PR TITLE
#1037 Support changing different status values from STF API to UI

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1198,6 +1198,18 @@ dbapi.setDeviceOwner = function(serial, owner) {
   }))
 }
 
+dbapi.markDeviceAsUsing = function(serial) {
+  return db.run(r.table('devices').get(serial).update({
+    using: true
+  }))
+}
+
+dbapi.unmarkDeviceAsUsing = function(serial) {
+  return db.run(r.table('devices').get(serial).update({
+    using: false
+  }))
+}
+
 dbapi.unsetDeviceOwner = function(serial) {
   return db.run(r.table('devices').get(serial).update({
     owner: null

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -526,32 +526,35 @@ function putDeviceInfoBySerial(req, res) {
       if (_.has(body, 'status')) {
         const status = body.status.trim().toLowerCase()
         switch (status) {
-          case "Disconnected":
+          case "disconnected":
             updates.push(dbapi.setDeviceAbsent(serial));
             break;
-          case "Offline":
+          case "offline":
             updates.push(dbapi.saveDeviceStatus(serial, 1));
             break;
-          case "Available":
+          case "available":
             updates.push(dbapi.saveDeviceStatus(serial, 3));
             updates.push(dbapi.unsetDeviceOwner(serial));
             updates.push(dbapi.unmarkDeviceAsUsing(serial));
             break;
-          case "Unauthorized":
+          case "unauthorized":
             updates.push(dbapi.saveDeviceStatus(serial, 5));
             break;
-          case "Preparing":
+          case "preparing":
             updates.push(dbapi.saveDeviceStatus(serial, 6));
             break;
-          case "Unhealthy":
+          case "unhealthy":
             updates.push(dbapi.saveDeviceStatus(serial, 7));
             break;
-          case "Busy":
-            if (!_.has(body, 'owner')) {
-              return apiutil.respond(res, 400, "Missing owner for busy status");
+          case "busy":
+            if (typeof body.owner?.name !== 'string' || !body.owner.name.trim()) {
+              return apiutil.respond(res, 400, "Missing owner.name for busy status")
             }
             updates.push(dbapi.saveDeviceStatus(serial, 3));
-            updates.push(dbapi.setDeviceOwner(serial, body.owner));
+            updates.push(dbapi.setDeviceOwner(serial, {
+              name: body.owner.name,
+              email: body.owner.email || ''
+            ));
             updates.push(dbapi.markDeviceAsUsing(serial));
             break;
           default:

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -554,7 +554,7 @@ function putDeviceInfoBySerial(req, res) {
             updates.push(dbapi.setDeviceOwner(serial, {
               name: body.owner.name,
               email: body.owner.email || ''
-            ));
+            }));
             updates.push(dbapi.markDeviceAsUsing(serial));
             break;
           default:

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -524,12 +524,35 @@ function putDeviceInfoBySerial(req, res) {
       }
 
       if (_.has(body, 'status')) {
-        switch (body.status) {
+        const status = body.status.trim().toLowerCase()
+        switch (status) {
           case "Disconnected":
             updates.push(dbapi.setDeviceAbsent(serial));
             break;
+          case "Offline":
+            updates.push(dbapi.saveDeviceStatus(serial, 1));
+            break;
+          case "Available":
+            updates.push(dbapi.saveDeviceStatus(serial, 3));
+            updates.push(dbapi.unsetDeviceOwner(serial));
+            updates.push(dbapi.unmarkDeviceAsUsing(serial));
+            break;
+          case "Unauthorized":
+            updates.push(dbapi.saveDeviceStatus(serial, 5));
+            break;
+          case "Preparing":
+            updates.push(dbapi.saveDeviceStatus(serial, 6));
+            break;
           case "Unhealthy":
             updates.push(dbapi.saveDeviceStatus(serial, 7));
+            break;
+          case "Busy":
+            if (!_.has(body, 'owner')) {
+              return apiutil.respond(res, 400, "Missing owner for busy status");
+            }
+            updates.push(dbapi.saveDeviceStatus(serial, 3));
+            updates.push(dbapi.setDeviceOwner(serial, body.owner));
+            updates.push(dbapi.markDeviceAsUsing(serial));
             break;
           default:
             apiutil.respond(res, 400, "Unknown status requested");

--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -50,6 +50,16 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.platform || device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.platform || device.image || '_default.jpg')
+    if (device.status === 5) {
+      device.enhancedStateAction = $filter('statusNameAction')('unauthorized')
+      device.enhancedStatePassive = $filter('statusNamePassive')('unauthorized')
+      return
+    }
+    if (device.using && device.owner) {
+      device.enhancedStateAction = $filter('statusNameAction')('using')
+      device.enhancedStatePassive = $filter('statusNamePassive')('using')
+      return
+    } 
     if (device.ios && device.state === "available" && !device.using) {
       device.enhancedStateAction = $filter('statusNameAction')('available')
       device.enhancedStatePassive = $filter('statusNamePassive')('available')

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -726,6 +726,10 @@ function DeviceStatusCell(options) {
         a.className = 'btn btn-xs device-status btn-warning-outline'
       }
 
+      if (device.status === 5 || device.status === 7) {
+        a.className = 'btn btn-xs device-status btn-danger-outline'
+      }
+
       if (device.status === 7) {
         a.className = 'btn btn-xs device-status btn-danger-outline'
       }

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -105,6 +105,10 @@ module.exports = function DeviceListIconsDirective(
           button.className = ('btn btn-xs device-status btn-warning-outline')
         } 
 
+        if (device.status === 5 || device.status === 7) {
+          button.className = ('btn btn-xs device-status btn-danger-outline')
+        } 
+
         if (device.status === 7) {
           button.className = ('btn btn-xs device-status btn-danger-outline')
         } 


### PR DESCRIPTION
The following PR allows users to update the device status from the STF API. These device status values are also visible in the UI, and inserting the `Busy` status **will also require** the `owner` property to be included in the request body (if owner contains `email` and `name` properties, these will also be visible in the UI to see who is using the device at that moment). The status change will not impact how the device works, but only the UI instead.

You can try testing by running:

`curl -X PUT "$STF_API_URL/devices/$UDID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "device": {
      "status": <status>,
      "owner": <{owner.email, owner.name}>
    }
  }' `